### PR TITLE
docs(slack): add comprehensive setup guide and CLAUDE.md for AI agents

### DIFF
--- a/modules/slack/CLAUDE.md
+++ b/modules/slack/CLAUDE.md
@@ -1,0 +1,98 @@
+# Slack Module - AI Agent Context
+
+This file captures project rules, conventions, and lessons learned for AI agents working on the Slack module. Following the [Boris Cherny Method](https://github.com/jhacksman/boris-method).
+
+## What This Module Does
+
+The Slack module collects messages from Slack workspaces and organizes them into FeedEater's Context system. Threads become their own contexts with AI-generated summaries.
+
+## Architecture
+
+### Data Flow
+
+1. **collect job** (every 5 min): Fetches messages from Slack API -> stores in `mod_slack.slack_messages` -> publishes `MessageCreated` events to NATS
+2. **updateContexts job** (every 30 min): Finds active threads -> uses semantic search to gather relevant messages -> generates AI summaries -> publishes `ContextUpdated` events
+
+### Context Key Format
+
+`{channelId}:{threadTs}` - e.g., `C01ABC123DE:1234567890.123456`
+
+Non-threaded messages use a template-based summary instead of AI generation.
+
+### Key Files
+
+- `src/ingest.ts` - Core `SlackIngestor` class with all collection and context logic
+- `src/runtime.ts` - Job handlers that wire up the ingestor
+- `module.json` - Job definitions, settings schema, UI cards
+- `settings.ts` - TypeScript types for settings (mirrors module.json)
+
+## Conventions
+
+### Settings
+
+All settings come from the FeedEater settings registry, not environment variables. The module fetches them via `ctx.fetchInternalSettings("slack")`.
+
+Secrets (like `botToken`) are encrypted at rest and only decrypted when fetched via the internal API.
+
+### Database
+
+- Private schema: `mod_slack`
+- Tables: `slack_messages`, `slack_message_embeddings`
+- Use `ensureSchema()` to create tables on first run
+- Never access other modules' schemas
+
+### Bus Events
+
+- Emit `MessageCreated` on `feedeater.slack.messageCreated`
+- Emit `ContextUpdated` on `feedeater.slack.contextUpdated`
+- Use `subjectFor("slack", "eventName")` helper
+
+### Logging
+
+Use the `log()` method which publishes to `feedeater.slack.log` for visibility in the FeedEater UI.
+
+## What NOT To Do
+
+- **Don't hardcode tokens** - Use the settings registry
+- **Don't skip deduplication** - The `collectAndPersist` method checks `(xmax = 0)` to detect true inserts vs updates
+- **Don't assume channel access** - The bot must be invited to private channels
+- **Don't fetch too much history** - Respect `lookbackHours` setting to avoid API rate limits
+- **Don't block on embedding failures** - Log and continue; embeddings are nice-to-have
+
+## Lessons Learned
+
+### Slack API Quirks
+
+- Channel IDs are not channel names (e.g., `C01ABC123DE` not `#general`)
+- Thread timestamps (`thread_ts`) identify threads, not individual messages
+- Bot tokens start with `xoxb-`, user tokens with `xoxp-`
+- Rate limits are per-workspace, not per-channel
+
+### Context Summarization
+
+- Prior summaries are used as query vectors to find semantically relevant messages
+- Fallback to recency-based selection if embeddings fail
+- JSON parsing of AI responses can fail; always have a plaintext fallback
+- Truncate prompts to ~8000 chars to avoid context window issues
+
+### Embedding Dimensions
+
+- Default is 4096 (Ollama's nomic-embed-text)
+- Changing dimensions requires recreating the embeddings table
+- IVFFlat indexes only work for dims <= 2000
+
+## Testing Locally
+
+1. Set up FeedEater's docker-compose environment
+2. Configure Slack settings in the UI (bot token, channel IDs)
+3. Trigger a manual `collect` job from the UI
+4. Check logs panel for errors
+5. Verify messages appear in the feed
+
+## Future Improvements
+
+- [ ] Support for Slack Connect channels
+- [ ] Reaction tracking (likes/emoji)
+- [ ] File/attachment handling
+- [ ] Real-time Socket Mode instead of polling
+- [ ] Better topic detection within long threads

--- a/modules/slack/README.md
+++ b/modules/slack/README.md
@@ -1,17 +1,129 @@
-## slack module
+## Slack Module
 
-Scrapes configured Slack channels and stores raw messages in the module schema `mod_slack`.
+Collects messages from your Slack workspace and organizes them into Contexts. Threads become their own contexts with AI-generated summaries, making it easy to catch up on conversations without reading every message.
 
-### What it stores
-Raw Slack message payloads (plus a few convenience columns) in:
-- `mod_slack.slack_messages`
+## Quick Start
 
-### Settings (module settings registry)
-- `enabled` (boolean)
-- `botToken` (secret): Slack bot token with `channels:history` (and `groups:history` if private channels) plus `users:read`
-- `channelIds` (string): comma-separated Slack channel IDs
-- `lookbackHours` (number)
-- `includeThreads` (boolean)
-- `excludeBots` (boolean)
+### Step 1: Create a Slack App
+
+1. Go to [https://api.slack.com/apps](https://api.slack.com/apps)
+2. Click **Create New App**
+3. Choose **From scratch**
+4. Name your app (e.g., "FeedEater") and select your workspace
+5. Click **Create App**
+
+### Step 2: Configure OAuth Scopes
+
+1. In the left sidebar, click **OAuth & Permissions**
+2. Scroll down to **Scopes** > **Bot Token Scopes**
+3. Add the following scopes:
+   - `channels:history` - Read messages from public channels
+   - `channels:read` - View basic channel info
+   - `groups:history` - Read messages from private channels (optional)
+   - `groups:read` - View basic private channel info (optional)
+   - `users:read` - View user display names
+
+### Step 3: Install the App to Your Workspace
+
+1. Scroll up to **OAuth Tokens for Your Workspace**
+2. Click **Install to Workspace**
+3. Review the permissions and click **Allow**
+4. Copy the **Bot User OAuth Token** (starts with `xoxb-`)
+
+### Step 4: Get Your Channel IDs
+
+Channel IDs are not the same as channel names. To find a channel ID:
+
+1. Open Slack in your browser or desktop app
+2. Right-click on the channel name > **View channel details** (or click the channel name)
+3. Scroll to the bottom of the details panel
+4. Copy the **Channel ID** (looks like `C01ABC123DE`)
+
+Alternatively, in the Slack web app, the channel ID is in the URL when viewing a channel:
+```
+https://app.slack.com/client/T00000000/C01ABC123DE
+                                       ^^^^^^^^^^^^^ this is the channel ID
+```
+
+### Step 5: Invite the Bot to Your Channels
+
+The bot can only read channels it has been invited to. For each channel you want to monitor:
+
+1. Open the channel in Slack
+2. Type `/invite @YourBotName` (use the name you gave your app in Step 1)
+3. Press Enter
+
+For private channels, you must also add the `groups:history` and `groups:read` scopes (Step 2).
+
+### Step 6: Configure FeedEater
+
+In the FeedEater web UI, go to **Settings** > **Slack** and configure:
+
+| Setting | Value |
+|---------|-------|
+| **Bot Token** | Your `xoxb-...` token from Step 3 |
+| **Channel IDs** | Comma-separated list of channel IDs (e.g., `C01ABC123DE,C02DEF456GH`) |
+| **Lookback Hours** | How far back to fetch messages (default: 24) |
+| **Include Threads** | Whether to fetch thread replies (default: true) |
+| **Exclude Bots** | Whether to skip bot messages (default: true) |
+
+### Step 7: Test It
+
+The Slack collector runs every 5 minutes by default. You can trigger a manual run from the FeedEater UI to test immediately.
+
+Check the **Logs** panel in FeedEater to see collection activity and any errors.
+
+## How It Works
+
+The Slack module runs two scheduled jobs:
+
+**collect** (every 5 minutes): Fetches new messages from your configured channels, stores them in the module's private database, and publishes them to the FeedEater message bus.
+
+**updateContexts** (every 30 minutes): Refreshes AI summaries for active threads. Uses semantic search to find the most relevant messages in each thread, then generates short and long summaries.
+
+## Context Keys
+
+Each Slack thread becomes its own Context with the key format: `{channelId}:{threadTs}`
+
+For example: `C01ABC123DE:1234567890.123456`
+
+Non-threaded messages get a simple context based on the channel name.
+
+## What It Stores
+
+Raw Slack message payloads (plus convenience columns) in:
+- `mod_slack.slack_messages` - All collected messages
+- `mod_slack.slack_message_embeddings` - Vector embeddings for semantic search
+
+## Settings Reference
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `enabled` | boolean | `true` | Enable/disable the module |
+| `botToken` | secret | required | Slack bot token (`xoxb-...`) |
+| `channelIds` | string | required | Comma-separated channel IDs |
+| `lookbackHours` | number | `24` | How far back to fetch messages |
+| `includeThreads` | boolean | `true` | Fetch thread replies |
+| `excludeBots` | boolean | `true` | Skip bot messages |
+| `nonThreadContextTemplate` | string | `"Message in channel {channel}"` | Summary template for non-threaded messages |
+| `channelNameMap` | string | `"{}"` | JSON mapping of channel IDs to friendly names |
+| `contextPrompt` | string | (see module.json) | System prompt for AI summaries |
+| `contextPromptFallback` | string | (see module.json) | Fallback prompt if JSON parsing fails |
+
+## Troubleshooting
+
+**"missing_scope" error**: Your bot token doesn't have the required scopes. Go back to Step 2 and add the missing scope, then reinstall the app.
+
+**"channel_not_found" error**: The channel ID is incorrect, or the bot hasn't been added to the channel. Invite the bot to the channel with `/invite @YourBotName`.
+
+**"not_in_channel" error**: The bot needs to be invited to the channel. Use `/invite @YourBotName` in the channel.
+
+**No messages appearing**: Check that `lookbackHours` is set high enough to capture recent messages. Also verify the channel has activity within that window.
+
+**Thread summaries not updating**: The `updateContexts` job runs every 30 minutes. You can trigger a manual run from the UI, or check the logs for errors.
+
+## For AI Agents
+
+See [CLAUDE.md](./CLAUDE.md) for detailed context on this module's architecture, conventions, and lessons learned.
 
 


### PR DESCRIPTION
Adds comprehensive documentation for the Slack module following the Boris Method.

## Changes

- **README.md**: Complete setup guide with step-by-step instructions for:
  - Creating a Slack app
  - Configuring OAuth scopes
  - Finding channel IDs
  - Inviting the bot to channels
  - Configuring FeedEater settings
  - Troubleshooting common errors

- **CLAUDE.md**: AI agent context file with:
  - Architecture overview and data flow
  - Key files and conventions
  - What NOT to do (lessons learned)
  - Testing instructions

## Link to Devin run
https://app.devin.ai/sessions/f3ec9a3195e34e99a8e5df9d72c4b6a0

Requested by: Jack Hacksman (slack@hannis.io)